### PR TITLE
fix(junit): use bom to apply correct platform launcher version

### DIFF
--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/features/JUnit5Feature.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/features/JUnit5Feature.kt
@@ -7,6 +7,7 @@ import me.philippheuer.projectcfg.domain.ProjectLanguage
 import me.philippheuer.projectcfg.util.DependencyVersion
 import me.philippheuer.projectcfg.util.PluginLogger
 import me.philippheuer.projectcfg.util.addDependency
+import me.philippheuer.projectcfg.util.addPlatformDependency
 import org.gradle.api.Project
 import org.gradle.api.logging.LogLevel
 import org.gradle.api.tasks.testing.Test
@@ -28,8 +29,9 @@ class JUnit5Feature constructor(override var ctx: IProjectContext) : PluginModul
     companion object {
         private fun configureJunitDependencies(project: Project, config: ProjectConfigurationExtension) {
             // junit
-            project.addDependency("testImplementation", "org.junit.jupiter:junit-jupiter:${DependencyVersion.junit5Version}")
-            project.addDependency("testRuntimeOnly", "org.junit.platform:junit-platform-launcher:${DependencyVersion.junit5Version}")
+            project.addPlatformDependency("testImplementation", "org.junit:junit-bom:${DependencyVersion.junit5Version}")
+            project.addDependency("testImplementation", "org.junit.jupiter:junit-jupiter")
+            project.addDependency("testRuntimeOnly", "org.junit.platform:junit-platform-launcher")
 
             // kotlin
             if (ProjectLanguage.KOTLIN.valueEquals(config.language.get())) {


### PR DESCRIPTION
Avoids `Could not find org.junit.platform:junit-platform-launcher:5.12.1` as in https://github.com/PhilippHeuer/events4j/actions/runs/14047171051/job/39330400427?pr=246 (the correct platform launcher version is `1.12.1`)
