### PR TITLE
feat: add AutomaticModuleNameFeature

### DIFF
--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/ProjectConfigurationPlugin.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/ProjectConfigurationPlugin.kt
@@ -11,6 +11,7 @@ import me.philippheuer.projectcfg.modules.features.JUnit5Feature
 import me.philippheuer.projectcfg.modules.features.JacocoFeature
 import me.philippheuer.projectcfg.modules.features.LoggingLibraryFeature
 import me.philippheuer.projectcfg.modules.features.LombokFeature
+import me.philippheuer.projectcfg.modules.features.AutomaticModuleNameFeature
 import me.philippheuer.projectcfg.modules.features.PublishFeature
 import me.philippheuer.projectcfg.modules.features.ReproducibleArchivesFeature
 import me.philippheuer.projectcfg.modules.features.ShadowFeature
@@ -53,6 +54,7 @@ abstract class ProjectConfigurationPlugin : Plugin<Project> {
                 JUnit5Feature(ctx),
                 LoggingLibraryFeature(ctx),
                 GitPropertiesFeature(ctx),
+                AutomaticModuleNameFeature(ctx),
                 ReproducibleArchivesFeature(ctx),
                 // check
                 CheckstyleFeature(ctx),

--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/features/AutomaticModuleNameFeature.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/features/AutomaticModuleNameFeature.kt
@@ -1,0 +1,57 @@
+package me.philippheuer.projectcfg.modules.features
+
+import me.philippheuer.projectcfg.domain.IProjectContext
+import me.philippheuer.projectcfg.domain.PluginModule
+import me.philippheuer.projectcfg.domain.ProjectLanguage
+import me.philippheuer.projectcfg.domain.ProjectType
+import me.philippheuer.projectcfg.util.PluginLogger
+import org.gradle.api.Project
+import org.gradle.api.logging.LogLevel
+import org.gradle.api.plugins.JavaPlugin
+import org.gradle.jvm.tasks.Jar
+
+/**
+ * Automatic Module Name for Java 9+ Module Support
+ *
+ * @see <a href="https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular_auto">Gradle Java Library Plugin - Automatic Module Name</a>
+ */
+class AutomaticModuleNameFeature(override var ctx: IProjectContext) : PluginModule {
+    override fun check(): Boolean {
+        if (!ctx.isProjectType(ProjectType.LIBRARY)) {
+            return false
+        }
+        if (!ctx.isProjectLanguage(ProjectLanguage.JAVA) && !ctx.isProjectLanguage(ProjectLanguage.KOTLIN)) {
+            return false
+        }
+        if (ctx.project.pluginManager.hasPlugin("java-platform") || ctx.project.pluginManager.hasPlugin("version-catalog")) {
+            return false
+        }
+
+        return !ctx.project.file("src/main/java/module-info.java").exists()
+    }
+
+    override fun run() {
+        configureAutoModuleName(ctx.project)
+    }
+
+    companion object {
+        private fun configureAutoModuleName(project: Project) {
+            val rootName = project.rootProject.name.replace('-', '.')
+            val currentName = project.name.replace('-', '.')
+            val moduleName = if (project != project.rootProject) {
+                "$rootName.$currentName"
+            } else {
+                currentName
+            }
+
+            PluginLogger.log(LogLevel.INFO, "setting manifest attr [Automatic-Module-Name] to [$moduleName]")
+            project.plugins.withType(JavaPlugin::class.java) {
+                project.tasks.withType(Jar::class.java).configureEach { jar ->
+                    jar.manifest { mf ->
+                        mf.attributes(mapOf("Automatic-Module-Name" to moduleName))
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
A plugin-based approach of the config in https://github.com/PhilippHeuer/events4j/pull/248 to apply across multiple projects.

Links from the original PR:
- https://dzone.com/articles/automatic-module-name-calling-all-java-library-maintainers
- https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_modular_auto