### PR TITLE
fix: dependency report task was breaking task caching

### DIFF
--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/DependencyReport.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/DependencyReport.kt
@@ -3,8 +3,10 @@ package me.philippheuer.projectcfg.modules.report
 import me.philippheuer.projectcfg.domain.IProjectContext
 import me.philippheuer.projectcfg.domain.PluginModule
 import me.philippheuer.projectcfg.modules.report.tasks.DependenciesReportResourcesTask
+import me.philippheuer.projectcfg.util.DependencyUtils
 
 private const val DEPENDENCY_REPORT_TASK_NAME = "projectcfg-dependency-report-resources"
+private const val DEPENDENCY_REPORT_OUTPUT_DIR = "generated/depreport/resources"
 
 class DependencyReport(override var ctx: IProjectContext) : PluginModule {
     override fun check(): Boolean {
@@ -19,7 +21,18 @@ class DependencyReport(override var ctx: IProjectContext) : PluginModule {
 
         // add task and add it to the task graph
         val task = ctx.project.tasks.register(DEPENDENCY_REPORT_TASK_NAME, DependenciesReportResourcesTask::class.java) {
-            it.fileName.set("dependencies.txt")
+            val deps = DependencyUtils.getResolvedDependencies(ctx.project, listOf("compileClasspath"))
+
+            it.outputFile.set(ctx.project.layout.buildDirectory.file("$DEPENDENCY_REPORT_OUTPUT_DIR/dependencies.txt").get().asFile)
+            it.dependencyList.set(deps)
+        }
+        ctx.project.extensions.getByName("sourceSets")
+            .let { it as org.gradle.api.tasks.SourceSetContainer }
+            .getByName("main")
+            .resources.srcDir(ctx.project.layout.buildDirectory.dir(DEPENDENCY_REPORT_OUTPUT_DIR))
+
+        ctx.project.tasks.named("processResources").configure {
+            it.dependsOn(task)
         }
         ctx.project.tasks.matching { it.name == "classes" }.configureEach {
             it.dependsOn(task)

--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/DependencyReport.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/DependencyReport.kt
@@ -34,7 +34,7 @@ class DependencyReport(override var ctx: IProjectContext) : PluginModule {
         ctx.project.tasks.named("processResources").configure {
             it.dependsOn(task)
         }
-        ctx.project.tasks.matching { it.name == "classes" }.configureEach {
+        ctx.project.tasks.matching { it.name == "classes" || it.name == "sourcesJar" }.configureEach {
             it.dependsOn(task)
             it.mustRunAfter("processResources")
         }

--- a/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/tasks/DependenciesReportResourcesTask.kt
+++ b/plugin/src/main/kotlin/me/philippheuer/projectcfg/modules/report/tasks/DependenciesReportResourcesTask.kt
@@ -1,36 +1,33 @@
 package me.philippheuer.projectcfg.modules.report.tasks
 
-import me.philippheuer.projectcfg.util.DependencyUtils
-import me.philippheuer.projectcfg.util.TaskUtils
 import org.gradle.api.DefaultTask
-import org.gradle.api.provider.Property
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.tasks.CacheableTask
 import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputFile
 import org.gradle.api.tasks.TaskAction
 import org.gradle.api.tasks.options.Option
 
+@CacheableTask
 abstract class DependenciesReportResourcesTask : DefaultTask() {
+
+    @get:Input
+    abstract val dependencyList: ListProperty<String>
+
+    @get:Option(option = "outputFile", description = "the output file name")
+    @get:OutputFile
+    abstract val outputFile: RegularFileProperty
 
     init {
         group = "projectcfg"
         description = "embeds a dependencies.txt into the resources, which is a list of all used dependencies + version"
     }
 
-    @get:Input
-    @get:Option(option = "fileName", description = "the fileName to create in the resources dir")
-    abstract val fileName: Property<String>
-
     @TaskAction
     fun generateDependencyReportAction() {
-        val dependencyReport = generateDependencyReport()
-
-        TaskUtils.writeContentToOutputResources(project, fileName.get(), dependencyReport)
-    }
-
-    private fun generateDependencyReport(): String {
-        val deps = DependencyUtils.getResolvedDependencies(project, listOf("compileClasspath"))
-
-        val content = StringBuilder()
-        deps.forEach { content.appendLine(it) }
-        return content.toString()
+        val content = dependencyList.get().sorted().joinToString("\n")
+        outputFile.get().asFile.parentFile.mkdirs()
+        outputFile.get().asFile.writeText(content)
     }
 }


### PR DESCRIPTION
- make `projectcfg-dependency-report-resources` cachable